### PR TITLE
merging Shawn's edits and additions

### DIFF
--- a/input.py
+++ b/input.py
@@ -1,0 +1,170 @@
+#! /usr/bin/env python
+# Copyright (C) 2018 Eugene Palovcak
+# University of California, San Francisco
+#
+# Program for training a convolutional neural network to denoise images 
+# from cryogenic electron microscopy (cryo-EM).
+# See README and help text for usage information.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+
+class train_input:
+	
+    _args = None
+
+    @classmethod
+    def getArgs(cls):
+        if cls._args != None:
+            return cls._args
+
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+        # Required arguments: 
+        # User must provide full path of the directory containing the 
+        # training mics (--training_mics, -m)
+        # OR training data HDF file (--trainind_data, -t)
+        parser.add_argument("--training_mics", "-m", 
+            type=str, default=None,
+            help="STAR file with micrographs and CTF information")
+        parser.add_argument("--training_data", "-t", 
+            type=str, default=None,
+            help="HDF file containing processed training data")
+
+        # Optional arguments
+        parser.add_argument("--even_odd_suffix", "-s", 
+            type=str, default="DW,EVN,ODD",
+            help="A comma-separated series of three suffixes.  \
+                  The first is a suffix in the training micrographs name. \
+                  The second is the suffix of the 'even' sums. \
+                  The third is the suffix of the 'odd' sums. \
+                                                             \
+                  If MotionCor2 is used to generate even/odd sums,\
+                  the default should be sufficient.")
+
+        parser.add_argument("--max_resolution", "-r", 
+            type=float, default=2.0, 
+            help="Max resolution to consider in training (angstroms). \
+                  Determines the extent of Fourier binning.")
+
+        parser.add_argument("--training_filename", "-f", 
+            type=str, default="training_data.hdf",
+            help="Name for the newly generated training data file.")
+
+        parser.add_argument("--initial_model", "-i", 
+            type=str, default=None,
+            help="Initialize training with this pre-trained model")
+
+        parser.add_argument("--batch_size", "-b", 
+            type=int, default=10,
+            help="Number of training examples used per training batch.")
+
+        parser.add_argument("--learning_rate", "-lr", 
+            type=float, default=1e-4,
+            help="Initial learning rate for training the neural network")
+
+        parser.add_argument("--number_of_epochs", 
+            type=int, default=10,
+            help="Number of training epochs to perform. \
+                  Model checkpoints are produced after every epoch.")
+
+        parser.add_argument("--batches_per_epoch", 
+            type=int, default=50,
+            help="Number of training batches per epoch")
+
+        parser.add_argument("--model_prefix", "-x", 
+            type=str, default="model", 
+            help="Prefix for model files containing the structure and \
+                  weights of the neural network.")
+
+        parser.add_argument("--model_directory", "-d", 
+            type=str, default="Models",
+            help="Directory where trained model files are saved")
+    
+        parser.add_argument("--phaseflip", dest="phaseflip", 
+            action="store_true",
+            help="Correct the CTF of the training images by phase-flipping")
+
+        parser.add_argument("--dont_phaseflip", dest="phaseflip", 
+            action="store_false",
+            help="Don't phase-flip the training images.") 
+
+        parser.set_defaults(phaseflip=True) 
+
+        cls._args = parser.parse_args()
+        return cls._args
+
+class denoise_input:
+
+    _args = None
+
+    @classmethod
+    def getArgs(cls):
+        if cls._args != None:
+            return cls._args
+        
+        parser = argparse.ArgumentParser()
+
+        parser.add_argument("--input_micrographs", "-m", 
+            type=str, default=None,
+            help="Input micrograph directory")
+
+        parser.add_argument("--model", "-p", 
+            type=str, default=None,
+            help="Neural network model with trained parameters")
+
+        parser.add_argument("--output_suffix", "-s", 
+            type=str, default="_denoised",
+            help="Suffix added to denoised image output")
+
+        parser.add_argument("--max_resolution", "-r", 
+            type=float, default=2.0,
+            help="Highest spatial frequencies to consider when denoising \
+                  (angstroms). Determines the extent of Fourier binning. \
+                  Should be consistent with the resolution of the \
+                  training data.")
+
+        parser.add_argument("--merge_resolution", "-x", 
+            type=float, default=0.03,
+            help="The center of passing band where denoised Fourier \
+                  components are merged")
+
+        parser.add_argument("--merge_width", "-w", 
+            type=float, default=0.20,
+            help="The width of the passing band where denoised Fourier \
+                  components are merged. At the cutoff frequent, the  \
+                  denoised Fourier component is suppressed to 1 percent \
+                  of its original value. The cutoff frequencies are at \
+                  central frequence +/- half of the width." )
+
+        parser.add_argument("--merge_noisy", dest="merge_noisy", 
+            action="store_true",
+            help="Merge the low-resolution denoised image with the \
+            high-resolution components of the raw image. If false,\
+                Otherwise, the merge filter is used as a lowpass filter.")
+
+        parser.add_argument("--dont_merge_noisy", 
+            dest="merge_noisy", action="store_false",
+            help="Don't merge the low-resolution denoised image with the \
+                  high-resolution noisy image")
+
+        parser.add_argument("--denoise_all", dest="denoiseAll",
+            action="store_true",
+            help="Denoise all MRC files in the input directory.")
+
+        cls._args = parser.parse_args()
+        return cls._args
+

--- a/restore.yml
+++ b/restore.yml
@@ -6,7 +6,8 @@ channels:
   - defaults
 dependencies:
   - python=3.6.7
-  - mrcfile=1.1.0
+  - cudatoolkit=11.8
+  - mrcfile=1.4.3
   - scipy=1.3.0
   - tensorflow-gpu=1.13
   - keras=2.2.4

--- a/restore/split_image.py
+++ b/restore/split_image.py
@@ -1,0 +1,138 @@
+#! /usr/bin/env python3
+# Copyright (C) 2018 Eugene Palovcak
+# University of California, San Francisco
+#
+# Utility functions for the restore program.
+# These are mainly for IO and image processing including
+# Fourier-based image resizing and Fourier filtering. 
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import mrcfile
+import numpy as np
+from itertools import product
+
+class SplitInfo:
+
+    def __init__(self):
+        self.iImgSizeX = 0
+        self.iImgSizeY = 0
+        self.iOverlap = 64
+        self.patStarts = None
+        self.patSizes = None
+        self.iNumPatchesX = 0
+        self.iNumPatchesY = 0
+
+class Split:
+
+    def __init__(self):
+        self.iPatSize = 1024
+    
+    def doIt(self, img):
+        if img.shape[0] <= self.iPatSize or img.shape[1] <= self.iPatSize:
+            return self.pad32(img)
+        #-------------------------
+        splitInfo = SplitInfo()
+        splitInfo.iImgSizeY = img.shape[0]
+        splitInfo.iImgSizeX = img.shape[1]
+        #---------------------------------
+        iPatSize = self.iPatSize - splitInfo.iOverlap
+        iSizeY = img.shape[0] - self.iPatSize
+        iSizeX = img.shape[1] - self.iPatSize
+        iRemainX = iSizeX % iPatSize
+        iRemainY = iSizeY % iPatSize
+        patStartXs = np.arange(0, iSizeX, iPatSize, dtype=np.int)
+        patStartYs = np.arange(0, iSizeY, iPatSize, dtype=np.int)
+	#--------------------------------------------------------
+        patSizeXs = np.full(patStartXs.shape, self.iPatSize)
+        patSizeYs = np.full(patStartYs.shape, self.iPatSize)
+        patSizeXs[-1] = (patSizeXs[-1] + iRemainX + 31) // 32 * 32
+        patSizeYs[-1] = (patSizeYs[-1] + iRemainY + 31) // 32 * 32
+        #----------------------------------------------------------
+        patStartYs[-1] = img.shape[0] - patSizeYs[-1]
+        patStartXs[-1] = img.shape[1] - patSizeXs[-1]
+        #--------------------------------------------
+        splitInfo.patStarts = [ s for s in product(patStartYs, patStartXs)]
+        splitInfo.patSizes = [ s for s in product(patSizeYs, patSizeXs)]
+        splitInfo.iNumPatchesX = patStartXs.shape[0];
+        splitInfo.iNumPatchesY = patStartYs.shape[0];
+        #--------------------------------------------
+        patches = []
+        for i in range(len(splitInfo.patStarts)):
+            start = splitInfo.patStarts[i]
+            size = splitInfo.patSizes[i]
+            patches.append(img[ start[0]:start[0]+size[0],
+                                     start[1]:start[1]+size[1] ])
+        return np.array(patches), splitInfo
+
+    def pad32(self, img):
+        splitInfo = SplitInfo()
+        splitInfo.iImgSizeY = img.shape[0]
+        splitInfo.iImgSizeX = img.shape[1]
+        splitInfo.iOverlap = 0
+        #---------------------
+        iPadY = (img.shape[0] + 31) // 32 * 32 - img.shape[0];
+        iPadX = (img.shape[1] + 31) // 32 * 32 - img.shape[1];
+        iBeforeX, iAfterX = iPadX // 2, iPadX - iPadX // 2
+        iBeforeY, iAfterY = iPadY // 2, iPadY - iPadY // 2;
+        
+        imgPadded = np.pad(img, ((iBeforeY, iAfterY), 
+            (iBeforeX, iAfterX)), mode='mean')
+        patches = []
+        patches.append(imgPadded)
+        return np.array(patches), splitInfo
+
+class Assemble:
+
+    def __init__(self):
+        return
+
+    def doIt(self, patArray, splitInfo, img):
+        if patArray.shape[0] == 1:
+            img = self.unpad32(patArray[0], img)
+            return img
+        #-------------
+        mean = np.mean(img)
+        img = np.full(img.shape, mean, dtype=np.float)
+        #---------------------------------------------
+        iHalfOverlap = splitInfo.iOverlap // 2;
+        for i in range(patArray.shape[0]):
+            iSizeY = splitInfo.patSizes[i][0]
+            iSizeX = splitInfo.patSizes[i][1]
+            #--------------------------------
+            iHalfOverlapX, iHalfOverlapY = 0, 0
+            iStartY = splitInfo.patStarts[i][0]
+            iStartX = splitInfo.patStarts[i][1] 
+            if (i % splitInfo.iNumPatchesX) > 0 :
+                iHalfOverlapX = iHalfOverlap
+                iStartX += iHalfOverlapX
+            if (i // splitInfo.iNumPatchesX) > 0:
+                iHalfOverlapY = iHalfOverlap
+                iStartY += iHalfOverlapY
+            #---------------------------
+            iEndX = splitInfo.patStarts[i][1] + iSizeX
+            iEndY = splitInfo.patStarts[i][0] + iSizeY
+            #-----------------------------------------
+            img[iStartY:iEndY, iStartX:iEndX] = \
+                patArray[i][iHalfOverlapY:iSizeY, iHalfOverlapX:iSizeX]
+            #----------------------------------------------------------
+        return img
+            
+    def unpad32(self, padImg, img):
+        iStartX = (padImg.shape[1] - img.shape[1]) // 2
+        iStartY = (padImg.shape[0] - img.shape[0]) // 2
+        img = padImg[ iStartY:iStartY+img.shape[0], 
+            iStartX:iStartX+img.shape[1]]
+        return img
+

--- a/restore/utils.py
+++ b/restore/utils.py
@@ -113,6 +113,16 @@ def get_mic_freqs(mic, apix, angles=False):
     else:
         return s
 
+def get_mic_relative_freqs(mic, angles=False):
+    '''Written by Shawn Zheng
+       Use to design filter
+    '''
+    n_x, n_y = mic.shape
+    x, y = np.meshgrid(rfftfreq(n_y), fftfreq(n_x))
+    s = np.sqrt(x**2 + y**2)
+    s = np.where(s > 0.5, 0.5, s) # cap at o.5
+    return s
+
 def fourier_crop(mic_ft, mic_freqs, cutoff):
     """Extract the portion of the real FT lower than a cutoff frequency"""
     n_x, n_y = mic_ft.shape

--- a/weighting.py
+++ b/weighting.py
@@ -1,0 +1,45 @@
+
+import numpy as np
+from numpy.fft import rfftfreq, fftfreq
+
+
+def get_mic_relative_freqs(mic, angles=False):
+    '''Written by Shawn Zheng
+       Use to design filter
+    '''
+    n_x, n_y = mic.shape
+    x, y = np.meshgrid(rfftfreq(n_y), fftfreq(n_x))
+    s = np.sqrt(x**2 + y**2)
+    s = np.where(s > 0.5, 0.5, s) # cap at 0.5
+    return s
+
+class denoise_weight:
+
+    _weight = None
+    _highPass = None
+
+    @classmethod
+    def calcWeight(cls, mic, f_cent, f_width):
+        # exponent 30 is selected that suppresses compenents of 0.125
+        # (8 pixel) and beyond to 0.01.
+        relative_freqs = get_mic_relative_freqs(mic)
+        a = np.log(2) - np.log((np.cos(np.pi * f_width) + 1)) + 1e-30
+        a = np.log(100) / a
+        weight1 = ((1 - np.cos(relative_freqs / f_cent * np.pi)) / 2) 
+        weight2 = ((np.cos((relative_freqs - f_cent) * np.pi * 2) + 1) \
+            / 2) ** a
+        cls._weight = np.where(relative_freqs < f_cent, weight1, weight2) 
+        print("Merge filter: " + str(f_cent) + " " + str(f_width) \
+            + " " + str(a))
+        #------------------
+        cls._highPass = ((1 - np.cos(relative_freqs * np.pi * 2)) / 2) \
+            * 0.9 + 0.1
+        cls._highPass = cls._highPass ** 0.5
+
+    @classmethod
+    def getWeight(cls):
+        return cls._weight
+
+    @classmethod
+    def getHighPass(cls):
+        return cls._highPass


### PR DESCRIPTION
The below list may not be comprehensive, but at a first glance some changes include:
1. _restore.yml_: specifying a cudatoolkit library and most recent version of mrcfile library
2. _input.py_: argparse classes for training and denoising, some arguments altered
3. _denoise.py_: numerous changes
4. _restore/split_image.py_: class to disassemble and reassemble images (?)
5. _restore/utils.py_: adding a `get_mic_relative_freqs`. However, this is a duplicate function! Also in weighting.py.
6. _weighting.py_: class for combining information at different spatial frequencies from original and denoised images
7. _train.py_: various changes, including for reading input files and disabling phase flipping