### PR TITLE
Random small fixes

### DIFF
--- a/restore/utils.py
+++ b/restore/utils.py
@@ -113,14 +113,14 @@ def get_mic_freqs(mic, apix, angles=False):
     else:
         return s
 
-def get_mic_relative_freqs(mic, angles=False):
+def get_mic_relative_freqs(mic):
     '''Written by Shawn Zheng
        Use to design filter
     '''
     n_x, n_y = mic.shape
     x, y = np.meshgrid(rfftfreq(n_y), fftfreq(n_x))
     s = np.sqrt(x**2 + y**2)
-    s = np.where(s > 0.5, 0.5, s) # cap at o.5
+    s = np.where(s > 0.5, 0.5, s) # cap at 0.5
     return s
 
 def fourier_crop(mic_ft, mic_freqs, cutoff):

--- a/train.py
+++ b/train.py
@@ -157,7 +157,7 @@ def generate_training_data(training_mics, cutoff, training_data, suffixes,
     training_data -- Filename for the HDF file that is created 
 
     It is presumed that all images have the same shape and pixel size. 
-    By default, phase-flipping is performed to correct for the CTF.
+    Phase-flipping is currently not performed to correct for the CTF.
     """
 
     aFullSumFiles = readMicFileNames(training_mics)
@@ -232,10 +232,8 @@ def process(cutoff, window, mic_file, freqs, angles,
     The following steps are performed:
     (1) The micrograph is loaded, Fourier transformed and Fourier cropped
     (2) A bandpass filter is applied with pass-band from cutoff to 1/200A
-    (3) The FT is multiplied by the sign of the CTF (phase-flipping)
-        This is a crude form of CTF correction. 
-    (4) The inverse FT is calculated to return to real-space
-    (5) The binned, filtered image is divided into patches, which are
+    (3) The inverse FT is calculated to return to real-space
+    (4) The binned, filtered image is divided into patches, which are
         normalized (Z-score normalization) and returned
     """
 

--- a/weighting.py
+++ b/weighting.py
@@ -1,17 +1,7 @@
 
 import numpy as np
 from numpy.fft import rfftfreq, fftfreq
-
-
-def get_mic_relative_freqs(mic, angles=False):
-    '''Written by Shawn Zheng
-       Use to design filter
-    '''
-    n_x, n_y = mic.shape
-    x, y = np.meshgrid(rfftfreq(n_y), fftfreq(n_x))
-    s = np.sqrt(x**2 + y**2)
-    s = np.where(s > 0.5, 0.5, s) # cap at 0.5
-    return s
+from restore.utils import get_mic_relative_freqs
 
 class denoise_weight:
 


### PR DESCRIPTION
Changes include:
1) duplicate `get_mic_relative_freqs` removed from weighting.py since it's already in restore/utils.py. The unused argument `angles` was also removed from the function.
2) correction to the docstring in train.py, since by default CTF correction is not performed.